### PR TITLE
Update URL regex to work with new launch pages

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,6 +1,6 @@
 // check for a zoom "status=success" redirect and close the tab
 
-var regex = /^((http[s]?):\/)?\/?((\/\w+)*)(.*)(zoom.us)((\/\w+)*\/)(.*)?status=success$/
+var regex = /^((http[s]?):\/)?\/?((\/\w+)*)(.*)(zoom.us)((\/\w+)*\/)(.*)?(status=|#)success$/
 
 function closeZoomTab(tabId, changeInfo, tab) {
     if (changeInfo.url) {


### PR DESCRIPTION
Zoom recently (within the last week) changed their launch pages such
that the URL matching in this extension no longer works. The new urls
are of the form:

  https://[company].zoom.us/j/1234567890#success

This PR updates the URL regex so that it works with both the old and new
style launch pages. Thanks for creating this extension!